### PR TITLE
Properly reset css based on https://meyerweb.com/eric/tools/css/reset/

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export const reset = {
   },
   "blockquote:before, blockquote:after, q:before, q:after": {
     content: "''",
-    '@supports (content: none)': {
+    "@supports (content: none)": {
       content: "none",
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,10 @@ export const reset = {
     quotes: "none",
   },
   "blockquote:before, blockquote:after, q:before, q:after": {
-    content: "",
-    // @ts-ignore
-    content: "none",
+    content: "''",
+    '@supports (content: none)': {
+      content: "none",
+    }
   },
   table: {
     borderSpacing: "0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export const reset = {
     }
   },
   table: {
+    borderCollapse: "collapse",
     borderSpacing: "0",
   },
 };


### PR DESCRIPTION
## Pull request checklist

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

Pretty sure the way js/ ts objects work, newer entries (top down) with the same key simply override older entries. This means the current
```js
{
    content: "",
    // @ts-ignore
    content: "none",
}
```
is actually just
```js
{
    content: "none",
}
```
which is technically wrong. Css does override as well *but* only if the style is supported. I'm not a stitches expert but I believe we can have support queries like so?

```js
{
    "@supports (<test style here, unapplied>)": {
      // apply style here
    },
}
```

I also saw that the default behavior for tables was a bit off looking at https://meyerweb.com/eric/tools/css/reset/

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

## Other information

I don't believe the styling for pseudo blockquote elements is breaking, however the table's border collapse may be breaking(?)

If you'd like, I could open separate prs since the table styling may not be alright.